### PR TITLE
Fix Docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,5 @@ WORKDIR /go/src/github.com/fabiofalci/sconsify
 
 # Upload sconsify source
 COPY . /go/src/github.com/fabiofalci/sconsify
+
+ENV PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
d69b4e5 breaks the docker build since it removes the full path
to the glide binary. So we add that path to the PATH environment
variable in the Dockerfile.