### PR TITLE
UI: Fix enter key play selected song behavior

### DIFF
--- a/ui/simple/cui_actions.go
+++ b/ui/simple/cui_actions.go
@@ -213,8 +213,12 @@ func keybindings() error {
 			return keyPressed(key, g, v)
 		}))
 	}
+	var specialKeys = []gocui.Key{
+		gocui.KeySpace, gocui.KeyArrowUp,
+		gocui.KeyArrowDown, gocui.KeyArrowLeft,
+		gocui.KeyArrowRight, gocui.KeyEnter}
 
-	for _, value := range []gocui.Key{gocui.KeySpace, gocui.KeyArrowUp, gocui.KeyArrowDown, gocui.KeyArrowLeft, gocui.KeyArrowRight} {
+	for _, value := range specialKeys {
 		key := value
 		addKeyBinding(&keyboard.Keys, newKeyMapping(key, "", func(g *gocui.Gui, v *gocui.View) error {
 			return keyPressed(rune(key), g, v)


### PR DESCRIPTION
This fixes issue #46
ENTER does not play song

Added gocui.KeyEnter to list that contains gocui.KeyArrow* + gocui.KeySpace
in the keybinding function.

The list was too long to be declared in-line on the for loop
so the list was initalized seperately.

Signed-Off-By Zach Brown <brownzach125@gmail.com>