### PR TITLE
UI: BUG: Fix pressing play after pausing

### DIFF
--- a/spotify/spotify_actions.go
+++ b/spotify/spotify_actions.go
@@ -5,8 +5,8 @@ import (
 	"github.com/fabiofalci/sconsify/sconsify"
 	sp "github.com/op/go-libspotify/spotify"
 	webspotify "github.com/zmb3/spotify"
-	"time"
 	"strings"
+	"time"
 )
 
 func (spotify *Spotify) shutdownSpotify() {
@@ -17,7 +17,7 @@ func (spotify *Spotify) shutdownSpotify() {
 
 func (spotify *Spotify) play(trackUri *sconsify.Track) {
 	player := spotify.session.Player()
-	if (!spotify.paused) {
+	if !spotify.paused || spotify.currentTrack != trackUri {
 		link, err := spotify.session.ParseLink(trackUri.URI)
 		if err != nil {
 			return


### PR DESCRIPTION
This commit addresses issue #57

When the spotify play function checks to see if it needs to load a
new track, the condition should be (not paused or new track not equal
oldtrack)